### PR TITLE
Modify gasp so that fuel_capacity includes unusable fuel on the aviar…

### DIFF
--- a/aviary/subsystems/mass/gasp_based/fuel.py
+++ b/aviary/subsystems/mass/gasp_based/fuel.py
@@ -47,6 +47,9 @@ class BodyTankCalculations(om.ExplicitComponent):
         add_aviary_input(self, Mission.Summary.FUEL_MASS, units='lbm')
         add_aviary_input(self, Mission.Summary.OPERATING_MASS, units='lbm')
 
+        # GASP total capacity didn't include the unusable mass, but Aviary total capacity does.
+        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS, units='lbm')
+
         # WFXTRA: extra amount of fuel that is required but does not fit in wings
         add_aviary_output(self, Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY, units='lbm')
         self.add_output(
@@ -108,6 +111,7 @@ class BodyTankCalculations(om.ExplicitComponent):
                 Mission.Summary.OPERATING_MASS,
             ],
         )
+        self.declare_partials(Aircraft.Fuel.TOTAL_CAPACITY, Aircraft.Fuel.UNUSABLE_FUEL_MASS, val=1.0)
 
     def compute(self, inputs, outputs):
         design_fuel_vol = inputs[Aircraft.Fuel.WING_VOLUME_DESIGN]
@@ -123,6 +127,7 @@ class BodyTankCalculations(om.ExplicitComponent):
         gross_wt_initial = inputs[Mission.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fuel_wt_des = inputs[Mission.Summary.FUEL_MASS] * GRAV_ENGLISH_LBM
         OEW = inputs[Mission.Summary.OPERATING_MASS] * GRAV_ENGLISH_LBM
+        unusable_fuel = inputs[Aircraft.Fuel.UNUSABLE_FUEL_MASS] * GRAV_ENGLISH_LBM
 
         smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
         mu = self.options['mu']
@@ -197,7 +202,7 @@ class BodyTankCalculations(om.ExplicitComponent):
         # pass back to FuelSysAndFullFuselageMass
         outputs['wingfuel_mass_min'] = wingfuel_wt_min / GRAV_ENGLISH_LBM
         # pass back to FuelAndOEMOutputs
-        outputs[Aircraft.Fuel.TOTAL_CAPACITY] = max_fuel_avail / GRAV_ENGLISH_LBM
+        outputs[Aircraft.Fuel.TOTAL_CAPACITY] = (max_fuel_avail + unusable_fuel) / GRAV_ENGLISH_LBM
 
     def compute_partials(self, inputs, J):
         design_fuel_vol = inputs[Aircraft.Fuel.WING_VOLUME_DESIGN]
@@ -513,6 +518,9 @@ class FuelAndOEMOutputs(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Fuel.FUEL_MARGIN, units='unitless')
         add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm')
 
+        # GASP total capacity didn't include the unusable mass, but Aviary total capacity does.
+        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS, units='lbm')
+
         self.add_output(
             'OEM_wingfuel_mass',
             val=0,
@@ -595,8 +603,9 @@ class FuelAndOEMOutputs(om.ExplicitComponent):
                 Aircraft.Design.SYSTEMS_AND_EQUIPMENT_MASS,
                 Mission.Summary.USEFUL_LOAD,
             ],
-            val=-1,
+            val=-1.0,
         )
+        self.declare_partials('payload_mass_max_fuel', Aircraft.Fuel.UNUSABLE_FUEL_MASS, val=1.0)
         self.declare_partials(
             'volume_wingfuel_mass', [Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX, Aircraft.Fuel.DENSITY]
         )
@@ -641,7 +650,10 @@ class FuelAndOEMOutputs(om.ExplicitComponent):
         req_fuel_wt = inputs[Mission.Summary.FUEL_MASS_REQUIRED] * GRAV_ENGLISH_LBM
         geometric_fuel_vol = inputs[Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX]
         fuel_margin = inputs[Aircraft.Fuel.FUEL_MARGIN]
-        max_fuel_avail = inputs[Aircraft.Fuel.TOTAL_CAPACITY] * GRAV_ENGLISH_LBM
+
+        total_fuel = inputs[Aircraft.Fuel.TOTAL_CAPACITY]
+        unusable_fuel = inputs[Aircraft.Fuel.UNUSABLE_FUEL_MASS]
+        max_fuel_avail = (total_fuel - unusable_fuel) * GRAV_ENGLISH_LBM
 
         OEM_wingfuel_wt = (
             gross_wt_initial - propulsion_wt - control_wt - struct_wt - fixed_equip_wt - useful_wt

--- a/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
@@ -3466,7 +3466,10 @@ class BWBMassSummationTestCase(unittest.TestCase):
         assert_near_equal(prob[Mission.Summary.OPERATING_MASS], 80987.12286499, tol)
         # BodyTankCalculations
         assert_near_equal(prob[Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY], 4954.00837132, tol)
-        assert_near_equal(prob[Aircraft.Fuel.TOTAL_CAPACITY], 40216.88550633, tol)
+
+        total_cap = prob[Aircraft.Fuel.TOTAL_CAPACITY]
+        unusable = prob[Aircraft.Fuel.UNUSABLE_FUEL_MASS]
+        assert_near_equal(total_cap - unusable, 40216.88550633, tol)
         assert_near_equal(prob['extra_fuel_volume'], 169.53050054, tol)
         assert_near_equal(prob['max_extra_fuel_mass'], 8480.29608482, tol)
         assert_near_equal(prob['wingfuel_mass_min'], 11782.58105019, tol)

--- a/aviary/validation_cases/benchmark_tests/test_bench_off_design.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_off_design.py
@@ -350,21 +350,21 @@ class Test2DOFOffDesign(unittest.TestCase):
             tolerance=1e-12,
         )
         assert_near_equal(
-            prob_fallout.get_val(Mission.Summary.RANGE), 3969.61096856, tolerance=1e-4
+            prob_fallout.get_val(Mission.Summary.RANGE), 3994.25223046, tolerance=1e-4
         )
         assert_near_equal(
             prob_fallout.get_val(Mission.Summary.FUEL_MASS, 'lbm'),
-            41131.31386858,
+            40505.09154366,
             tolerance=1e-6,
         )
         assert_near_equal(
             prob_fallout.get_val(Mission.Summary.TOTAL_FUEL_MASS, 'lbm'),
-            39710.31045975,
+            39910.0046378,
             tolerance=1e-6,
         )
         assert_near_equal(
             prob_fallout.get_val(Mission.Summary.OPERATING_MASS, 'lbm'),
-            95289.68954025,
+            95089.9953622,
             tolerance=1e-6,
         )
         assert_near_equal(
@@ -432,17 +432,17 @@ class Test2DOFOffDesign(unittest.TestCase):
         assert_near_equal(prob_alternate.get_val(Mission.Summary.RANGE), 1800, tolerance=1e-6)
         assert_near_equal(
             prob_alternate.get_val(Mission.Summary.FUEL_MASS, 'lbm'),
-            41131.31386858,
+            40505.07149946,
             tolerance=1e-6,
         )
         assert_near_equal(
             prob_alternate.get_val(Mission.Summary.TOTAL_FUEL_MASS, 'lbm'),
-            21492.26201255,
+            21484.2904701,
             tolerance=1e-6,
         )
         assert_near_equal(
             prob_alternate.get_val(Mission.Summary.OPERATING_MASS, 'lbm'),
-            95289.68954025,
+            95089.98897155,
             tolerance=1e-6,
         )
         assert_near_equal(
@@ -473,7 +473,7 @@ class Test2DOFOffDesign(unittest.TestCase):
         )
         assert_near_equal(
             prob_alternate.get_val(Mission.Summary.GROSS_MASS, 'lbm'),
-            148881.95154364,
+            148674.27944164,
             tolerance=1e-6,
         )
         assert_near_equal(

--- a/aviary/validation_cases/benchmark_tests/test_bwb_GwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bwb_GwGm.py
@@ -41,13 +41,13 @@ class ProblemPhaseTestCase(unittest.TestCase):
         # There are no truth values for these.
         assert_near_equal(
             prob.get_val(Mission.Design.GROSS_MASS, units='lbm'),
-            140507.90163112,
+            139803.667415,
             tolerance=rtol,
         )
 
         assert_near_equal(
             prob.get_val(Mission.Summary.OPERATING_MASS, units='lbm'),
-            80023.24844905,
+            79873.05255347,
             tolerance=rtol,
         )
 
@@ -59,7 +59,7 @@ class ProblemPhaseTestCase(unittest.TestCase):
 
         assert_near_equal(
             prob.get_val(Mission.Landing.GROUND_DISTANCE, units='ft'),
-            2211.43592871,
+            2216.0066613,
             tolerance=rtol,
         )
 
@@ -67,7 +67,7 @@ class ProblemPhaseTestCase(unittest.TestCase):
 
         assert_near_equal(
             prob.get_val(Mission.Landing.TOUCHDOWN_MASS, units='lbm'),
-            116152.7250992,
+            116003.31044998,
             tolerance=rtol,
         )
 

--- a/aviary/validation_cases/benchmark_tests/test_problem_types_GwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_problem_types_GwGm.py
@@ -12,7 +12,7 @@ from aviary.variable_info.enums import ProblemType, Verbosity
 class TwoDOFTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.sized_mass = 171044.0
-        self.sized_range = 3594
+        self.sized_range = 3675
         self.phase_info = deepcopy(phase_info)
 
 


### PR DESCRIPTION
…y side, but excludes it in the gasp component calculations. Restored truth values for all tests.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None